### PR TITLE
Fix missing wound display on floater HP bar

### DIFF
--- a/Assets/Scripts/Token/TokenController.cs
+++ b/Assets/Scripts/Token/TokenController.cs
@@ -103,6 +103,13 @@ public class TokenController : MonoBehaviour
             Token.TokenHeld.GetComponent<UnitState>().Blessings--;
         });
 
+        edit.Q<Button>("WND-up").RegisterCallback<ClickEvent>((evt) => {
+            Token.TokenHeld.GetComponent<HpBar>().Wounds++;
+        });
+        edit.Q<Button>("WND-down").RegisterCallback<ClickEvent>((evt) => {
+            Token.TokenHeld.GetComponent<HpBar>().Wounds--;
+        });
+
         edit.Q<TextField>("HatredEdit").RegisterValueChangedCallback((evt) => {
             Token.TokenHeld.GetComponent<UnitState>().Hatred = evt.newValue;
         });


### PR DESCRIPTION
Add in missing controller parts to update the Wounds value.

The UI for the floater HP bar already has the code to update the UI, so you can see the changes immediately there when the buttons are clicked.  The focus info panel HP bar still does not reflect wounds.  This change doesn't update that.  (The info panel seems to be missing the UI elements to show, I think.)

Tested this via running the code in Unity, creating a token, selecting it and updating the wounds.  Going to negative or -4 doesn't have any strange behavior.