### PR TITLE
Reworked the code around Focus on Blocks, and added ability to focus a row or column when resizing the map.

### DIFF
--- a/Assets/Scripts/Map/Block.cs
+++ b/Assets/Scripts/Map/Block.cs
@@ -21,11 +21,26 @@ public enum BlockShape
 
 public class Block : MonoBehaviour
 {
-    public static Block LastFocused;
+    // public static Block LastFocused;
 
     // Focus State
-    public bool Selected = false;
-    public bool Focused = false;
+    public bool Selected { get; private set; } = false;
+    private bool _focused = false;
+    public bool Focused
+    {
+        get => _focused;
+        set
+        {
+            if (value == _focused)
+                return;
+            _focused = value;
+            _allFocused.Add(this);
+            MaterialReset = true;
+        }
+    }
+    static private HashSet<Block> _allFocused = new();// HashSet<Block>();
+    static public IEnumerable<Block> AllFocusedBlocks => _allFocused;
+
     public bool Highlighted = false;
 
     public BlockShape Shape = BlockShape.Solid;
@@ -66,9 +81,6 @@ public class Block : MonoBehaviour
             indicator.SetActive(false);
         }
 
-        if (Focused && this != LastFocused) {
-            Unfocus();
-        }
 
         if (MaterialReset) {
             MaterialReset = false;
@@ -557,37 +569,28 @@ public class Block : MonoBehaviour
 
     #region Focus
     public void Focus() {
-        LastFocused = this;
+        UnfocusAll();
         Focused = true;
-        MaterialReset = true;
         TerrainController.SetInfo();
         Player.Self().GetComponent<DestinationRenderer>().SetTarget(getMidpoint());
     }
 
     public void Unfocus() {
         Focused = false;
-        LastFocused = null;
-        MaterialReset = true;
+        _allFocused.Remove(this);
     }
 
     public static Block[] GetFocused() {
-        List<Block> focused = new();
-        GameObject[] gos = GameObject.FindGameObjectsWithTag("Block");
-        for (int i = 0; i < gos.Length; i++) {
-            Block block = gos[i].GetComponent<Block>();
-            if (block.Focused) {
-                focused.Add(block);
-            }
-        }
-        return focused.ToArray();
-    }
+        return _allFocused.ToArray();
 
+    }
 
     public static void UnfocusAll() {
         Player.Self().GetComponent<DestinationRenderer>().UnsetTarget();
         foreach (Block b in GetFocused()) {
             b.Unfocus();
         }
+        _allFocused.Clear();
     }
     #endregion
     
@@ -650,5 +653,51 @@ public class Block : MonoBehaviour
 
     public Token GetToken() {
         return Token.GetAtBlock(this);    
+    }
+
+    /// <summary>
+    /// Get the top blocks at the given coordinates
+    /// </summary>
+    /// <param name="coordinates"></param>
+    /// <returns></returns>
+    public static Block[] GetTopBlocks(Vector2Int[] coordinates)
+    {
+        GameObject[] gameObjects = GameObject.FindGameObjectsWithTag("Block");
+        List<Block> blocks = new List<Block>();
+        List<Vector2Int> v2is = new List<Vector2Int>(coordinates);
+        foreach (var gameObject in gameObjects)
+        {
+            Block block = gameObject.GetComponent<Block>();
+            Vector2Int blockCoords = new Vector2Int(block.getX(), block.getY());
+            if (v2is.Contains(blockCoords))
+            {
+                Block topBlock = block.transform.parent.GetComponent<Column>().GetTopBlock();
+                blocks.Add(topBlock);
+            }
+            v2is.Remove(blockCoords);
+            if (v2is.Count() == 0)
+                return blocks.ToArray();
+        }
+        return blocks.ToArray();
+    }
+
+    /// <summary>
+    /// Gets the top block at a given coordinate, returns null if it would be out of bounds.
+    /// </summary>
+    /// <param name="coordinate"></param>
+    /// <returns></returns>
+    public static Block GetTopBlock(Vector2Int coordinate)
+    {
+        GameObject[] gameObjects = GameObject.FindGameObjectsWithTag("Block");
+        foreach(var gameObject in gameObjects)
+        {
+            Block block = gameObject.GetComponent<Block>();
+            if(block.getX() == coordinate.x && block.getY() == coordinate.y)
+            {
+                Block topBlock = block.transform.parent.GetComponent<Column>().GetTopBlock();
+                return topBlock;
+            }
+        }
+        return null;
     }
 }

--- a/Assets/Scripts/Map/Column.cs
+++ b/Assets/Scripts/Map/Column.cs
@@ -31,4 +31,8 @@ public class Column : MonoBehaviour
         }
         transform.localPosition = v;
     }
+
+    public Block GetTopBlock() {
+        return transform.GetChild(transform.childCount - 1).GetComponent<Block>();
+    }
 }

--- a/Assets/Scripts/Map/CoordinateUtility.cs
+++ b/Assets/Scripts/Map/CoordinateUtility.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+static public class CoordinateUtility
+{
+
+    static public Vector2Int[] GetRow(Vector2Int v2)
+    {
+        var coords = new Vector2Int[99];
+        for(int x = 0; x < 99; x++)
+        {
+            coords[x] = new Vector2Int(x, v2.y);
+        } 
+        return coords;
+    }
+
+    static public Vector2Int[] GetColumn(Vector2Int v2)
+    {
+        var coords = new Vector2Int[99];
+        for (int y = 0; y < 99; y++)
+        {
+            coords[y] = new Vector2Int(v2.x, y);
+        }
+        return coords;
+    }
+
+    static public Vector2Int[] OffsetCoordinates(Vector2Int center, Vector2Int[] offsets)
+    {
+        var coords = new Vector2Int[offsets.Length];
+        for (int i = 0; i < coords.Length; i++)
+        {
+            coords[i] = center + offsets[i];
+        }
+        return coords;
+    }
+
+    static public Vector2Int[] GetCardinallyAdjacent(Vector2Int center)
+    {
+        return OffsetCoordinates(center, new Vector2Int[]{Vector2Int.left, Vector2Int.up, Vector2Int.right, Vector2Int.down });
+    }
+}

--- a/Assets/Scripts/Map/CoordinateUtility.cs
+++ b/Assets/Scripts/Map/CoordinateUtility.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 static public class CoordinateUtility
 {
 
-    static public Vector2Int[] GetRow(Vector2Int v2)
+    static public Vector2Int[] GetColumn(Vector2Int v2)
     {
         var coords = new Vector2Int[99];
         for(int x = 0; x < 99; x++)
@@ -14,8 +14,8 @@ static public class CoordinateUtility
         } 
         return coords;
     }
-
-    static public Vector2Int[] GetColumn(Vector2Int v2)
+    
+    static public Vector2Int[] GetRow(Vector2Int v2)
     {
         var coords = new Vector2Int[99];
         for (int y = 0; y < 99; y++)

--- a/Assets/Scripts/Map/CoordinateUtility.cs.meta
+++ b/Assets/Scripts/Map/CoordinateUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5295ceaf8bf14fd4d92468e1b82571ca

--- a/Assets/Scripts/Map/TerrainController.cs
+++ b/Assets/Scripts/Map/TerrainController.cs
@@ -536,7 +536,7 @@ public class TerrainController : MonoBehaviour
         UI.ToggleDisplay(root, false);
 
         Block[] selected = Block.GetSelected();
-        Block focused = Block.LastFocused;
+        Block focused = Block.AllFocusedBlocks.FirstOrDefault();
         Block block = null;
 
         if (selected.Length == 0 && focused == null) {

--- a/Assets/Scripts/UI/v0.6/Cursor.cs
+++ b/Assets/Scripts/UI/v0.6/Cursor.cs
@@ -11,9 +11,16 @@ public enum CursorMode {
     TerrainEffecting
 }
 
+public enum FocusMode {
+    Single,
+    Row,
+    Column,
+}
+
 public class Cursor : MonoBehaviour
 {  
     public static CursorMode Mode = CursorMode.Default;
+    public static FocusMode FocusMode { get; set; } = FocusMode.Single;
     private static Ray ray;
     public static bool OverUnitBarElement = false;
 
@@ -44,7 +51,7 @@ public class Cursor : MonoBehaviour
             Token t = Token.GetAtBlock(b);
             if (t != null) {
                 TokenHit(t);
-                b.Focus();
+                Focus(b);
             }
             else {
                 BlockHit(b);
@@ -53,7 +60,7 @@ public class Cursor : MonoBehaviour
         }
         else if (isHit && hit.collider.tag == "TokenCollider") {
             Token t = hit.collider.GetComponent<Cutout>().GetToken();
-            t.GetBlock().Focus();
+            Focus(t.GetBlock());
             TokenHit(t);
         }
         else if (!isHit) {
@@ -74,10 +81,37 @@ public class Cursor : MonoBehaviour
         }
 
         if (!b.Focused) {
-            b.Focus();
+            Focus(b);
         }
         
         BlockClicks(b);
+    }
+
+    private void Focus(Block b)
+    {
+        switch (FocusMode)
+        {
+            case FocusMode.Single:
+                b.Focus();
+                break;
+            case FocusMode.Row:
+                Block.UnfocusAll();
+                foreach (var block in Block.GetTopBlocks(CoordinateUtility.GetRow(new Vector2Int(b.getX(), b.getY()))))
+                {
+                    block.Focused = true;
+                }
+                break;
+            case FocusMode.Column:
+                Block.UnfocusAll();
+                foreach (var block in Block.GetTopBlocks(CoordinateUtility.GetColumn(new Vector2Int(b.getX(), b.getY()))))
+                {
+                    block.Focused = true;
+                }
+                break;
+            default:
+                Debug.LogError($"Unsupported Focus Mode {FocusMode}");
+                break;
+        }
     }
 
     private void TokenHit(Token t) {

--- a/Assets/Scripts/UI/v0.6/Cursor.cs
+++ b/Assets/Scripts/UI/v0.6/Cursor.cs
@@ -42,6 +42,7 @@ public class Cursor : MonoBehaviour
             return;
         }
 
+        SetFocusMode();
         ray = Camera.main.ScreenPointToRay(Input.mousePosition);
 
         RaycastHit hit;
@@ -166,5 +167,33 @@ public class Cursor : MonoBehaviour
 
     public static bool IsLeftClick() {
         return Input.GetMouseButtonDown(0);
+    }
+
+    private void SetFocusMode() {
+        if (Mode == CursorMode.Editing) {
+            switch (MapEdit.EditOp)
+            {
+                case "ResizeMap":
+                    switch (MapEdit.ResizeOp)
+                    {
+                        case "ResizeCloneRow":
+                        case "ResizeDeleteRow":
+                            FocusMode = FocusMode.Row;
+                            break;
+                        case "ResizeCloneCol":
+                        case "ResizeDeleteCol":
+                            FocusMode = FocusMode.Column;
+                            break;
+                        default:
+                            FocusMode = FocusMode.Single;
+                            break;
+                    }
+                    break;
+                default:
+                    FocusMode = FocusMode.Single;
+                    break;
+
+            }
+        }
     }
 }

--- a/Assets/Scripts/UI/v0.6/MapEdit.cs
+++ b/Assets/Scripts/UI/v0.6/MapEdit.cs
@@ -244,6 +244,7 @@ public class MapEdit
     private static void EndEditing() {
         Tutorial.Init("end edit");
         Cursor.Mode = CursorMode.Default;
+        Cursor.FocusMode = FocusMode.Single;
         BlockMesh.ToggleBorders(false);
         UI.ToggleDisplay("ToolsPanel", false);
         UI.ToggleDisplay("ToolOptions", false);


### PR DESCRIPTION
Encapsulated the Block. Focused into a property, it should handle the internal states needed without external calls needing to rely on method calls to do it properly. Focus() is now a shorthand for Focusing on the Block and Unfocusing previously Focused block.

Added static methods for Looking up Blocks in Block. This functionallty might be moved elsewhere, I just needed them to make this code function, and previous code I found for multiselection was not helpful.

Added a coordinateUtility that can be expanded upon with future use, it should be fairly self explanatory.

