### PR TITLE
Unity didnt Update Layers, also coordinate refactoring on Blocks and Clumns

### DIFF
--- a/Assets/Scripts/Map/Block.cs
+++ b/Assets/Scripts/Map/Block.cs
@@ -49,6 +49,9 @@ public class Block : MonoBehaviour
 
     private bool _materialReset = true;
 
+    public Vector3Int Coordinate => transform.parent.GetComponent<Column>().Coordinate3 + new Vector3Int(0, 0, (int)(transform.position.y / .5f) + 2);
+    public Vector2Int Coordinate2 => transform.parent.GetComponent<Column>().Coordinate;
+
     private Vector3 _dragOrigin;
     private bool _dragging;
 
@@ -335,7 +338,7 @@ public class Block : MonoBehaviour
                     case "RemoveBlock":
                         if (editZ != GetZ())
                             return;
-                        if (GetTopBlock(new Vector2Int(GetX(), GetY())) != this)
+                        if (GetTopBlock(Coordinate2) != this)
                             return;
                         goto case "StyleBlock";
                     case "StyleBlock":
@@ -377,20 +380,18 @@ public class Block : MonoBehaviour
         BlockMesh.GetSharedMaterial(id).SetColor("_Color", color);
     }
 
-    public int GetX()
-    {
-        return this.transform.parent.GetComponent<Column>().X;
-    }
-
-    public int GetY()
-    {
-        return this.transform.parent.GetComponent<Column>().Y;
-    }
-
-    public int GetZ()
-    {
-        return (int)(this.transform.position.y / .5f) + 2;
-    }
+    /// <summary>
+    /// (depriciated) Use Coordinate.x instead.
+    /// </summary>
+    public int GetX() => Coordinate.x;
+    /// <summary>
+    /// (depriciated) Use Coordinate.y instead.
+    /// </summary>
+    public int GetY() => Coordinate.y;
+    /// <summary>
+    /// (depriciated) Use Coordinate.z instead.
+    /// </summary>
+    public int GetZ() => Coordinate.z;
 
     public float GetHeight()
     {
@@ -810,7 +811,7 @@ public class Block : MonoBehaviour
         foreach (var gameObject in gameObjects)
         {
             Block block = gameObject.GetComponent<Block>();
-            Vector2Int blockCoords = new Vector2Int(block.GetX(), block.GetY());
+            Vector2Int blockCoords = block.Coordinate2;
             if (v2is.Contains(blockCoords))
             {
                 Block topBlock = block.transform.parent.GetComponent<Column>().GetTopBlock();
@@ -834,7 +835,7 @@ public class Block : MonoBehaviour
         foreach (var gameObject in gameObjects)
         {
             Block block = gameObject.GetComponent<Block>();
-            if (block.GetX() == coordinate.x && block.GetY() == coordinate.y)
+            if (block.Coordinate2 == coordinate)
             {
                 Block topBlock = block.transform.parent.GetComponent<Column>().GetTopBlock();
                 return topBlock;

--- a/Assets/Scripts/Map/Column.cs
+++ b/Assets/Scripts/Map/Column.cs
@@ -2,33 +2,24 @@ using UnityEngine;
 
 public class Column : MonoBehaviour
 {
-    private int _x;
-    public int X
-    {
-        get { return _x; }
-        private set { _x = value; }
-    }
-
-    private int _y;
-    public int Y
-    {
-        get { return _y; }
-        private set { _y = value; }
-    }
+    public int X { get; private set; }
+    public int Y { get; private set; }
+    public Vector2Int Coordinate => new Vector2Int(X, Y);
+    public Vector3Int Coordinate3 => new Vector3Int(X, Y, 0);
 
     public void Set(int x, int y)
     {
-        this._x = x;
-        this._y = y;
+        X = x;
+        Y = y;
     }
 
     void Update()
     {
-        Vector3 v = new(_x, 0, _y);
+        Vector3 v = new Vector3(X, 0, Y);
         if (TerrainController.GridType == "Hex")
         {
             v.z *= .866f;
-            if (_y % 2 == 1)
+            if (Y % 2 == 1)
             {
                 v.x += .5f;
             }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -20,8 +20,8 @@ TagManager:
   - Water
   - UI
   - NoProjection
-  - 
-  - 
+  - Token
+  - Block
   - 
   - 
   - 


### PR DESCRIPTION
Sorry about this update.

I didn't save the Unity project so some changes were still cashed in editor. Specifically the new Layers for Token and Block, which means current master should be broken. Its a simple fix.

Noticed this after I did some refactoring of block coordinates to use a Vector3Int and Vector2Int property instead of GetX() and GetY(), and GetZ(), I believe this is a good change, but if you wish to reject that, simply reject this Pull Request, and add the Token and Block layer to the project yourself next update.