### PR TITLE
Framerate Limiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
+/*.vsconfig

--- a/Assets/Scripts/System/Startup.cs
+++ b/Assets/Scripts/System/Startup.cs
@@ -26,6 +26,7 @@ public class Startup
         TokenLibrary.Setup();
 
         UI.SetBlocking(UI.System, StringUtility.CreateArray(@"SelectionMenu", "TopBar", "BottomBar", "ToolsPanel", "ToolOptions", "SelectedTokenPanel", "FocusedTokenPanel", "Backdrop"));
+        Application.targetFrameRate = Preferences.Current.TargetFramerate;
 
         // Useful during development when editing UI
         UI.ToggleDisplay("Tabletop", false);

--- a/Assets/Scripts/UI/Config.cs
+++ b/Assets/Scripts/UI/Config.cs
@@ -43,6 +43,16 @@ public class Config
             Preferences.SetTokenScale(evt.newValue);
         });
 
+        int framerate = Preferences.Current.TargetFramerate;
+        Modal.AddIntField("TargetFramerate", "FPS Limit", framerate, (evt) =>
+        {
+            if (evt.newValue > 3)
+            {
+                Preferences.SetTargetFramerate(evt.newValue);
+                Application.targetFrameRate = evt.newValue;
+            }
+        });
+
         float borderOpacity = Preferences.Current.BlockBorderOpacity;
         Modal.AddFloatSlider("BlockBorderOpacity", "Block Border Minimum", borderOpacity, 1, 0, (evt) =>
         {

--- a/Assets/Scripts/Utility/Preferences.cs
+++ b/Assets/Scripts/Utility/Preferences.cs
@@ -21,6 +21,7 @@ public class StoredPreferences
     public bool OverrideRules;
     public string RulesFile;
     public bool ShowHUD;
+    public int TargetFramerate;
 }
 
 public class Preferences
@@ -57,6 +58,7 @@ public class Preferences
                 TutorialsSeen = PlayerPrefs.GetString("TutorialsSeen", ""),
                 ReleaseNotesSeen = PlayerPrefs.GetString("ReleaseNotesSeen", ""),
                 SkipTutorials = PlayerPrefs.GetInt("SkipTutorials", 0),
+                TargetFramerate = PlayerPrefs.GetInt("TargetFramerate", 30),
                 ShowHUD = true
             };
             Save();
@@ -168,6 +170,12 @@ public class Preferences
     public static void SetRulesFile(string value)
     {
         _current.RulesFile = value;
+        Save();
+    }
+
+    public static void SetTargetFramerate(int value)
+    {
+        _current.TargetFramerate = value;
         Save();
     }
 


### PR DESCRIPTION
Added framerate limiter to the Options Menu, defaults to 30, should be fine for a turn based application.

![image](https://github.com/delzhand/isocon/assets/22002617/80d71a6c-36d5-414e-98ca-92feb23453f3)

![image](https://github.com/delzhand/isocon/assets/22002617/227cd268-4fb8-47a1-bda4-74f07039f801)

Stonks!

So I added the line straight in the Startup.cs
Since its application configuration, it seemed appropiate, could be refactored later if more application configurations are needed?
