### PR TITLE
Fixed bug in loading foe stats by class

### DIFF
--- a/Assets/Scripts/GameSystems/Icon_v2_0.cs
+++ b/Assets/Scripts/GameSystems/Icon_v2_0.cs
@@ -345,7 +345,7 @@ public class Icon_v2_0 : GameSystem
             data.Class = foeClass;
             data.Job = foeJob;
             data.Elite = elite;
-            JSONNode stats = gamedata["Icon2_0"]["FoeClasses"][playerJob];
+            JSONNode stats = gamedata["Icon2_0"]["FoeClasses"][foeClass];
             data.MaxHP = stats[0];
             data.Move = stats[1];
             data.Defense = stats[2];


### PR DESCRIPTION
Fixed a bug in the Icon 2.0 game system script that caused tokens to use the input in the `playerJob` field to index `FoeClasses`, rather than input in the `foeClass` field, when assigning the token's stats during token creation