### PR TITLE
Add mob/enemy menu options back to ICON 2.0 player actor type

### DIFF
--- a/Assets/Scripts/ActorTypes/Icon2x0/Icon2x0PlayerActorType.cs
+++ b/Assets/Scripts/ActorTypes/Icon2x0/Icon2x0PlayerActorType.cs
@@ -209,6 +209,20 @@ public class Icon2x0PlayerActorType : Icon2x0Base
     //     return baseItems.Concat(items.ToArray()).ToArray();
     // }
 
+        public override List<MenuItem> GetMenuItems(bool placed)
+    {
+        var baseItems = base.GetMenuItems(placed);
+
+        var changeValues = FindParent("Change Values", baseItems);
+
+        changeValues.Children.Add(new MenuItem("Modify HP", () => { NumberPicker.ActorCommand("ModHP"); }));
+        changeValues.Children.Add(new MenuItem("Modify Vigor", () => { NumberPicker.ActorCommand("ModVIG"); }));
+        changeValues.Children.Add(new MenuItem("Modify Resolve", () => { NumberPicker.ActorCommand("ModRES"); }));
+        changeValues.Children.Add(new MenuItem("Modify Party Resolve", () => { NumberPicker.AllTokensCommand("ModPRES"); }));
+
+        return baseItems;
+    }
+
     public override void Command(string command, ActorData tokenData)
     {
         base.Command(command, tokenData);


### PR DESCRIPTION
In this commit it looks like the Modify HP/Vigor menu options were added back to the ICON 2.0 Enemy and Mob actors: https://github.com/delzhand/isocon/commit/a958ebc12bb761af28880e5134c284e230e5d99d

However, they're still missing on ICON 2.0 Player actors, which means currently they can't have their HP/Vigor increased through the menu. Resolve/Party Resolve is similarly unable to be changed.

This PR mirrors the changes to the other actor types on the ICON 2.0 Player actor type.